### PR TITLE
【Codex】保留同步唤醒亲和性

### DIFF
--- a/ext4-fs/src/lib.rs
+++ b/ext4-fs/src/lib.rs
@@ -34,7 +34,7 @@ pub const BLOCK_SZ: usize = 4096;
 pub use block_dev::BlockDevice;
 pub use error::{Ext4Error, Result};
 pub use ext4::Ext4FileSystem;
-pub use vfs::Inode;
+pub use vfs::{Inode, InodeStatSnapshot};
 
 pub use block_cache::cache_stats;
 use block_cache::{block_cache_sync_all, get_block_cache};

--- a/ext4-fs/src/vfs.rs
+++ b/ext4-fs/src/vfs.rs
@@ -110,6 +110,26 @@ pub struct Inode {
     block_size: usize,
 }
 
+#[derive(Clone, Copy)]
+pub struct InodeStatSnapshot {
+    pub inode_num: u32,
+    pub mode: u16,
+    pub uid: u32,
+    pub gid: u32,
+    pub nlink: u32,
+    pub size: u64,
+    pub special_rdev: u64,
+}
+
+impl InodeStatSnapshot {
+    pub fn rdev_for_mode(&self) -> u64 {
+        match self.mode & S_IFMT {
+            S_IFCHR | S_IFBLK => self.special_rdev,
+            _ => 0,
+        }
+    }
+}
+
 impl Inode {
     pub fn inode_num(&self) -> u32 {
         self.inode_num
@@ -222,6 +242,19 @@ impl Inode {
     /// Get cached block size
     pub fn block_size(&self) -> usize {
         self.block_size
+    }
+
+    /// Read stat-relevant inode metadata with one block-cache lookup.
+    pub fn stat_snapshot(&self) -> InodeStatSnapshot {
+        self.read_disk_inode(|inode| InodeStatSnapshot {
+            inode_num: self.inode_num,
+            mode: inode.i_mode,
+            uid: inode.i_uid as u32,
+            gid: inode.i_gid as u32,
+            nlink: inode.i_links_count as u32,
+            size: inode.size(),
+            special_rdev: ((inode.i_block[1] as u64) << 32) | inode.i_block[0] as u64,
+        })
     }
 
     /// Read the disk inode

--- a/ext4-fs/src/vfs.rs
+++ b/ext4-fs/src/vfs.rs
@@ -94,6 +94,26 @@ fn inode_caches_invalidate(inode_num: u32, block_device: &Arc<dyn BlockDevice>) 
     extents_cache_invalidate(inode_num, block_device);
 }
 
+#[cfg(debug_assertions)]
+fn debug_assert_extents_ordered(extents: &[Ext4Extent]) {
+    for pair in extents.windows(2) {
+        let prev = pair[0];
+        let next = pair[1];
+        let prev_end = prev.ee_block.saturating_add(prev.len());
+        debug_assert!(
+            prev_end <= next.ee_block,
+            "ext4 extents are not sorted or overlap: prev [{}, {}), next [{}, {})",
+            prev.ee_block,
+            prev_end,
+            next.ee_block,
+            next.ee_block.saturating_add(next.len())
+        );
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn debug_assert_extents_ordered(_extents: &[Ext4Extent]) {}
+
 /// Virtual filesystem inode
 pub struct Inode {
     /// Inode number
@@ -596,10 +616,9 @@ impl Inode {
                 data
             });
             let extents = self.parse_extent_tree(&inode_data, block_size);
+            debug_assert_extents_ordered(&extents);
             extents_cache_put(self.inode_num, &self.block_device, extents)
         };
-        // Sparse regions inside an extent-based file must read back as zeros.
-        buf.fill(0);
         self.read_from_extents(&extents, offset, buf, block_size)
     }
 
@@ -716,6 +735,7 @@ impl Inode {
     ) -> usize {
         let file_start = offset;
         let file_end = offset.saturating_add(buf.len());
+        let mut covered_until = file_start;
 
         for extent in extents {
             let extent_start = extent.ee_block as usize * block_size;
@@ -732,13 +752,23 @@ impl Inode {
             if read_end <= read_start {
                 continue;
             }
+            if read_end <= covered_until {
+                continue;
+            }
+
+            let copy_start = core::cmp::max(read_start, covered_until);
+            if copy_start > covered_until {
+                let gap_start = covered_until - file_start;
+                let gap_end = copy_start - file_start;
+                buf[gap_start..gap_end].fill(0);
+            }
 
             // Destination offset in the caller's buffer (relative to requested `offset`).
-            let mut dst_off = read_start - file_start;
-            let mut remaining = read_end - read_start;
+            let mut dst_off = copy_start - file_start;
+            let mut remaining = read_end - copy_start;
 
             // Calculate physical position within the extent.
-            let offset_in_extent = read_start - extent_start;
+            let offset_in_extent = copy_start - extent_start;
             let mut cur_block = extent.start_block() as usize + offset_in_extent / block_size;
             let mut phys_off = offset_in_extent % block_size;
 
@@ -757,6 +787,12 @@ impl Inode {
                 phys_off = 0;
                 cur_block += 1;
             }
+            covered_until = read_end;
+        }
+
+        if covered_until < file_end {
+            let gap_start = covered_until - file_start;
+            buf[gap_start..].fill(0);
         }
 
         buf.len()

--- a/user/src/bin/exec_write_count_smoke.rs
+++ b/user/src/bin/exec_write_count_smoke.rs
@@ -1,0 +1,137 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+#[macro_use]
+extern crate user;
+
+use user::syscall::{CREATE, RDONLY, RDWR, TRUNC, close, execve, exit, fork, open, openat, read};
+use user::syscall::{syscall, waitpid, write};
+
+const SYSCALL_UNLINKAT: usize = 35;
+const AT_FDCWD: isize = -100;
+const ETXTBSY: isize = -26;
+
+const SRC: &str = "/user/basename.bin";
+const TARGET: &str = "/tmp/exec_write_count_smoke.bin";
+const TARGET_C: &str = "/tmp/exec_write_count_smoke.bin\0";
+const ARG0: &str = "exec_write_count_smoke.bin\0";
+const ARG1: &str = "ok\0";
+const ARG2: &str = "extra\0";
+const ARG3: &str = "fail\0";
+
+fn unlinkat(path: &str) -> isize {
+    let mut owned = alloc::string::String::from(path);
+    owned.push('\0');
+    syscall(
+        SYSCALL_UNLINKAT,
+        [AT_FDCWD as usize, owned.as_ptr() as usize, 0, 0, 0, 0],
+    )
+}
+
+fn copy_exec_target() {
+    let _ = unlinkat(TARGET);
+    let src = open(SRC, RDONLY);
+    assert!(src >= 0);
+    let dst = openat(AT_FDCWD, TARGET, RDWR | CREATE | TRUNC, 0o755);
+    assert!(dst >= 0);
+    let src = src as usize;
+    let dst = dst as usize;
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = read(src, &mut buf);
+        assert!(n >= 0);
+        if n == 0 {
+            break;
+        }
+        let n = n as usize;
+        assert_eq!(write(dst, &buf[..n]), n as isize);
+    }
+    assert_eq!(close(src), 0);
+    assert_eq!(close(dst), 0);
+}
+
+fn wait_exit_zero(pid: isize) {
+    let mut status = 0i32;
+    assert_eq!(waitpid(pid, &mut status), pid);
+    assert_eq!(status, 0);
+}
+
+fn expect_exec_etxtbsy(write_fd: usize) {
+    let pid = fork();
+    assert!(pid >= 0);
+    if pid == 0 {
+        assert_eq!(close(write_fd), 0);
+        let args = [
+            ARG0.as_ptr(),
+            ARG1.as_ptr(),
+            ARG2.as_ptr(),
+            ARG3.as_ptr(),
+            core::ptr::null(),
+        ];
+        let env = [core::ptr::null()];
+        let ret = execve(TARGET_C, &args, &env);
+        if ret == ETXTBSY {
+            exit(0);
+        }
+        println!("exec while write-open returned {}", ret);
+        exit(1);
+    }
+    wait_exit_zero(pid);
+}
+
+fn expect_exec_success() {
+    let pid = fork();
+    assert!(pid >= 0);
+    if pid == 0 {
+        let args = [ARG0.as_ptr(), ARG1.as_ptr(), core::ptr::null()];
+        let env = [core::ptr::null()];
+        let ret = execve(TARGET_C, &args, &env);
+        println!("exec after close returned {}", ret);
+        exit(1);
+    }
+    wait_exit_zero(pid);
+}
+
+fn expect_two_independent_writers() {
+    let fd1 = open(TARGET, RDWR);
+    assert!(fd1 >= 0);
+    let fd2 = open(TARGET, RDWR);
+    assert!(fd2 >= 0);
+
+    assert_eq!(close(fd1 as usize), 0);
+    expect_exec_etxtbsy(fd2 as usize);
+    assert_eq!(close(fd2 as usize), 0);
+    expect_exec_success();
+}
+
+fn expect_exec_after_writer_exit() {
+    let pid = fork();
+    assert!(pid >= 0);
+    if pid == 0 {
+        let fd = open(TARGET, RDWR);
+        assert!(fd >= 0);
+        exit(0);
+    }
+    wait_exit_zero(pid);
+    expect_exec_success();
+}
+
+#[unsafe(no_mangle)]
+pub fn main() -> i32 {
+    copy_exec_target();
+
+    let write_fd = open(TARGET, RDWR);
+    assert!(write_fd >= 0);
+    expect_exec_etxtbsy(write_fd as usize);
+    expect_exec_etxtbsy(write_fd as usize);
+    assert_eq!(close(write_fd as usize), 0);
+
+    expect_two_independent_writers();
+    expect_exec_after_writer_exit();
+    expect_exec_success();
+    let _ = unlinkat(TARGET);
+    println!("exec_write_count_smoke passed");
+    0
+}

--- a/user/src/bin/path_cache_invalidation_smoke.rs
+++ b/user/src/bin/path_cache_invalidation_smoke.rs
@@ -1,0 +1,140 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+#[macro_use]
+extern crate user;
+
+use alloc::string::String;
+use user::syscall::{CREATE, RDWR, TRUNC, close, open, syscall, write};
+
+const SYSCALL_UNLINKAT: usize = 35;
+const SYSCALL_RENAMEAT: usize = 38;
+const SYSCALL_NEWFSTATAT: usize = 79;
+
+const AT_FDCWD: isize = -100;
+const ENOENT: isize = -2;
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct KStat {
+    st_dev: u64,
+    st_ino: u64,
+    st_mode: u32,
+    st_nlink: u32,
+    st_uid: u32,
+    st_gid: u32,
+    st_rdev: u64,
+    __pad: u64,
+    st_size: i64,
+    st_blksize: u32,
+    __pad2: i32,
+    st_blocks: u64,
+    st_atime_sec: i64,
+    st_atime_nsec: i64,
+    st_mtime_sec: i64,
+    st_mtime_nsec: i64,
+    st_ctime_sec: i64,
+    st_ctime_nsec: i64,
+    __unused: [u32; 2],
+}
+
+fn with_c_path<T>(path: &str, f: impl FnOnce(*const u8) -> T) -> T {
+    let mut owned = String::from(path);
+    owned.push('\0');
+    f(owned.as_ptr())
+}
+
+fn linux_newfstatat(path: &str, st: &mut KStat) -> isize {
+    with_c_path(path, |ptr| {
+        syscall(
+            SYSCALL_NEWFSTATAT,
+            [
+                AT_FDCWD as usize,
+                ptr as usize,
+                st as *mut KStat as usize,
+                0,
+                0,
+                0,
+            ],
+        )
+    })
+}
+
+fn linux_unlinkat(path: &str) -> isize {
+    with_c_path(path, |ptr| {
+        syscall(
+            SYSCALL_UNLINKAT,
+            [AT_FDCWD as usize, ptr as usize, 0, 0, 0, 0],
+        )
+    })
+}
+
+fn linux_renameat(old_path: &str, new_path: &str) -> isize {
+    with_c_path(old_path, |old_ptr| {
+        with_c_path(new_path, |new_ptr| {
+            syscall(
+                SYSCALL_RENAMEAT,
+                [
+                    AT_FDCWD as usize,
+                    old_ptr as usize,
+                    AT_FDCWD as usize,
+                    new_ptr as usize,
+                    0,
+                    0,
+                ],
+            )
+        })
+    })
+}
+
+fn create_file(path: &str, data: &[u8]) {
+    let fd = open(path, RDWR | CREATE | TRUNC);
+    assert!(fd >= 0);
+    let fd = fd as usize;
+    assert_eq!(write(fd, data), data.len() as isize);
+    assert_eq!(close(fd), 0);
+}
+
+fn stat_twice(path: &str) -> KStat {
+    let mut st = KStat::default();
+    assert_eq!(linux_newfstatat(path, &mut st), 0);
+    assert_eq!(linux_newfstatat(path, &mut st), 0);
+    st
+}
+
+fn assert_missing(path: &str) {
+    let mut st = KStat::default();
+    assert_eq!(linux_newfstatat(path, &mut st), ENOENT);
+}
+
+#[unsafe(no_mangle)]
+pub fn main() -> i32 {
+    let old_path = "/tmp/path_cache_invalidation_smoke.old";
+    let new_path = "/tmp/path_cache_invalidation_smoke.new";
+    let unlink_path = "/tmp/path_cache_invalidation_smoke.unlink";
+
+    let _ = linux_unlinkat(old_path);
+    let _ = linux_unlinkat(new_path);
+    let _ = linux_unlinkat(unlink_path);
+
+    create_file(old_path, b"rename");
+    let before = stat_twice(old_path);
+    assert_eq!(linux_renameat(old_path, new_path), 0);
+    assert_missing(old_path);
+
+    let after = stat_twice(new_path);
+    assert_eq!(before.st_dev, after.st_dev);
+    assert_eq!(before.st_ino, after.st_ino);
+    assert_eq!(linux_unlinkat(new_path), 0);
+    assert_missing(new_path);
+
+    create_file(unlink_path, b"unlink");
+    let _ = stat_twice(unlink_path);
+    assert_eq!(linux_unlinkat(unlink_path), 0);
+    assert_missing(unlink_path);
+
+    println!("path_cache_invalidation_smoke passed");
+    0
+}

--- a/user/src/bin/pending_write_stat_smoke.rs
+++ b/user/src/bin/pending_write_stat_smoke.rs
@@ -1,0 +1,273 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+#[macro_use]
+extern crate user;
+
+use alloc::string::String;
+use user::syscall::{CREATE, RDWR, TRUNC, close, open, syscall, write};
+
+const SYSCALL_UNLINKAT: usize = 35;
+const SYSCALL_FTRUNCATE: usize = 46;
+const SYSCALL_OPENAT: usize = 56;
+const SYSCALL_LSEEK: usize = 62;
+const SYSCALL_PWRITE64: usize = 68;
+const SYSCALL_FSTAT: usize = 80;
+const SYSCALL_MUNMAP: usize = 215;
+const SYSCALL_MMAP: usize = 222;
+const SYSCALL_NEWFSTATAT: usize = 79;
+
+const AT_FDCWD: isize = -100;
+const O_RDWR: usize = 0x2;
+const O_CREAT: usize = 0x40;
+const O_TRUNC: usize = 0x200;
+const O_APPEND: usize = 0x400;
+const SEEK_END: usize = 2;
+const PAGE_SIZE: usize = 4096;
+const PROT_READ: usize = 1;
+const PROT_WRITE: usize = 2;
+const MAP_SHARED: usize = 0x01;
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct KStat {
+    st_dev: u64,
+    st_ino: u64,
+    st_mode: u32,
+    st_nlink: u32,
+    st_uid: u32,
+    st_gid: u32,
+    st_rdev: u64,
+    __pad: u64,
+    st_size: i64,
+    st_blksize: u32,
+    __pad2: i32,
+    st_blocks: u64,
+    st_atime_sec: i64,
+    st_atime_nsec: i64,
+    st_mtime_sec: i64,
+    st_mtime_nsec: i64,
+    st_ctime_sec: i64,
+    st_ctime_nsec: i64,
+    __unused: [u32; 2],
+}
+
+fn with_c_path<T>(path: &str, f: impl FnOnce(*const u8) -> T) -> T {
+    let mut owned = String::from(path);
+    owned.push('\0');
+    f(owned.as_ptr())
+}
+
+fn linux_newfstatat(path: &str, st: &mut KStat) -> isize {
+    with_c_path(path, |ptr| {
+        syscall(
+            SYSCALL_NEWFSTATAT,
+            [
+                AT_FDCWD as usize,
+                ptr as usize,
+                st as *mut KStat as usize,
+                0,
+                0,
+                0,
+            ],
+        )
+    })
+}
+
+fn linux_unlinkat(path: &str) -> isize {
+    with_c_path(path, |ptr| {
+        syscall(
+            SYSCALL_UNLINKAT,
+            [AT_FDCWD as usize, ptr as usize, 0, 0, 0, 0],
+        )
+    })
+}
+
+fn linux_openat(path: &str, flags: usize) -> isize {
+    with_c_path(path, |ptr| {
+        syscall(
+            SYSCALL_OPENAT,
+            [AT_FDCWD as usize, ptr as usize, flags, 0o666, 0, 0],
+        )
+    })
+}
+
+fn linux_fstat(fd: usize, st: &mut KStat) -> isize {
+    syscall(SYSCALL_FSTAT, [fd, st as *mut KStat as usize, 0, 0, 0, 0])
+}
+
+fn pwrite64(fd: usize, buf: &[u8], off: usize) -> isize {
+    syscall(
+        SYSCALL_PWRITE64,
+        [fd, buf.as_ptr() as usize, buf.len(), off, 0, 0],
+    )
+}
+
+fn mmap_shared(fd: usize, len: usize) -> isize {
+    syscall(
+        SYSCALL_MMAP,
+        [0, len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0],
+    )
+}
+
+fn munmap(addr: usize, len: usize) -> isize {
+    syscall(SYSCALL_MUNMAP, [addr, len, 0, 0, 0, 0])
+}
+
+fn lseek_end(fd: usize) -> isize {
+    syscall(SYSCALL_LSEEK, [fd, 0, SEEK_END, 0, 0, 0])
+}
+
+fn ftruncate(fd: usize, len: usize) -> isize {
+    syscall(SYSCALL_FTRUNCATE, [fd, len, 0, 0, 0, 0])
+}
+
+fn assert_path_size(path: &str, expected_size: usize) {
+    let mut st = KStat::default();
+    assert_eq!(linux_newfstatat(path, &mut st), 0);
+    assert_eq!(st.st_size, expected_size as i64);
+}
+
+fn assert_fd_size(fd: usize, expected_size: usize) {
+    let mut st = KStat::default();
+    assert_eq!(linux_fstat(fd, &mut st), 0);
+    assert_eq!(st.st_size, expected_size as i64);
+}
+
+#[unsafe(no_mangle)]
+pub fn main() -> i32 {
+    let pending_path = "/tmp/pending_write_stat_smoke.pending";
+    let multi_fd_path = "/tmp/pending_write_stat_smoke.multi";
+    let append_path = "/tmp/pending_write_stat_smoke.append";
+    let zero_path = "/tmp/pending_write_stat_smoke.zero";
+    let mmap_path = "/tmp/pending_write_stat_smoke.mmap";
+    let trunc_path = "/tmp/pending_write_stat_smoke.trunc";
+    let otrunc_path = "/tmp/pending_write_stat_smoke.otrunc";
+    let pending_off = 64 * 1024 + 17;
+    let multi_fd_off = 96 * 1024 + 7;
+    let append_off = 112 * 1024 + 5;
+    let zero_off = 128 * 1024 + 33;
+    let mmap_off = PAGE_SIZE + 123;
+
+    let _ = linux_unlinkat(pending_path);
+    let _ = linux_unlinkat(multi_fd_path);
+    let _ = linux_unlinkat(append_path);
+    let _ = linux_unlinkat(zero_path);
+    let _ = linux_unlinkat(mmap_path);
+    let _ = linux_unlinkat(trunc_path);
+    let _ = linux_unlinkat(otrunc_path);
+
+    let fd = open(pending_path, RDWR | CREATE | TRUNC);
+    assert!(fd >= 0);
+    let fd = fd as usize;
+    assert_eq!(pwrite64(fd, b"x", pending_off), 1);
+    assert_path_size(pending_path, pending_off + 1);
+    assert_eq!(lseek_end(fd), (pending_off + 1) as isize);
+    assert_eq!(close(fd), 0);
+    assert_path_size(pending_path, pending_off + 1);
+
+    let fd1 = open(multi_fd_path, RDWR | CREATE | TRUNC);
+    assert!(fd1 >= 0);
+    let fd1 = fd1 as usize;
+    let fd2 = open(multi_fd_path, RDWR);
+    assert!(fd2 >= 0);
+    let fd2 = fd2 as usize;
+    assert_eq!(pwrite64(fd1, b"f", multi_fd_off), 1);
+    assert_fd_size(fd2, multi_fd_off + 1);
+    assert_eq!(lseek_end(fd2), (multi_fd_off + 1) as isize);
+    assert_eq!(close(fd1), 0);
+    assert_eq!(close(fd2), 0);
+    assert_path_size(multi_fd_path, multi_fd_off + 1);
+
+    let fd1 = linux_openat(append_path, O_RDWR | O_CREAT | O_TRUNC);
+    assert!(fd1 >= 0);
+    let fd1 = fd1 as usize;
+    let fd2 = linux_openat(append_path, O_RDWR | O_APPEND);
+    assert!(fd2 >= 0);
+    let fd2 = fd2 as usize;
+    assert_eq!(pwrite64(fd1, b"x", append_off), 1);
+    let append_map_len = append_off + PAGE_SIZE;
+    let append_map = mmap_shared(fd1, append_map_len);
+    assert!(append_map > 0);
+    let _ = unsafe { core::ptr::read_volatile((append_map as usize + append_off) as *const u8) };
+    assert_eq!(write(fd2, b"a"), 1);
+    let appended =
+        unsafe { core::ptr::read_volatile((append_map as usize + append_off + 1) as *const u8) };
+    assert_eq!(appended, b'a');
+    assert_eq!(munmap(append_map as usize, append_map_len), 0);
+    assert_fd_size(fd2, append_off + 2);
+    assert_eq!(lseek_end(fd2), (append_off + 2) as isize);
+    assert_eq!(close(fd1), 0);
+    assert_eq!(close(fd2), 0);
+    assert_path_size(append_path, append_off + 2);
+
+    let fd = open(zero_path, RDWR | CREATE | TRUNC);
+    assert!(fd >= 0);
+    let fd = fd as usize;
+    let empty: [u8; 0] = [];
+    assert_eq!(pwrite64(fd, &empty, zero_off), 0);
+    assert_path_size(zero_path, 0);
+    assert_eq!(lseek_end(fd), 0);
+    assert_eq!(close(fd), 0);
+    assert_path_size(zero_path, 0);
+
+    let fd = open(mmap_path, RDWR | CREATE | TRUNC);
+    assert!(fd >= 0);
+    let fd = fd as usize;
+    assert_eq!(pwrite64(fd, b"m", 0), 1);
+    let mapped = mmap_shared(fd, PAGE_SIZE * 2);
+    assert!(mapped > 0);
+    assert_eq!(pwrite64(fd, b"z", mmap_off), 1);
+    assert_eq!(close(fd), 0);
+    assert_path_size(mmap_path, mmap_off + 1);
+    let trunc_fd = linux_openat(mmap_path, O_RDWR);
+    assert!(trunc_fd >= 0);
+    let trunc_fd = trunc_fd as usize;
+    assert_eq!(ftruncate(trunc_fd, 0), 0);
+    assert_eq!(close(trunc_fd), 0);
+    assert_path_size(mmap_path, 0);
+    assert_eq!(munmap(mapped as usize, PAGE_SIZE * 2), 0);
+    assert_path_size(mmap_path, 0);
+
+    let fd1 = open(trunc_path, RDWR | CREATE | TRUNC);
+    assert!(fd1 >= 0);
+    let fd1 = fd1 as usize;
+    let fd2 = open(trunc_path, RDWR);
+    assert!(fd2 >= 0);
+    let fd2 = fd2 as usize;
+    assert_eq!(pwrite64(fd1, b"t", pending_off), 1);
+    assert_path_size(trunc_path, pending_off + 1);
+    assert_eq!(ftruncate(fd2, 0), 0);
+    assert_fd_size(fd1, 0);
+    assert_eq!(lseek_end(fd1), 0);
+    assert_eq!(close(fd2), 0);
+    assert_eq!(close(fd1), 0);
+    assert_path_size(trunc_path, 0);
+
+    let fd1 = open(otrunc_path, RDWR | CREATE | TRUNC);
+    assert!(fd1 >= 0);
+    let fd1 = fd1 as usize;
+    assert_eq!(pwrite64(fd1, b"o", pending_off), 1);
+    assert_path_size(otrunc_path, pending_off + 1);
+    let fd2 = linux_openat(otrunc_path, O_RDWR | O_TRUNC);
+    assert!(fd2 >= 0);
+    let fd2 = fd2 as usize;
+    assert_fd_size(fd1, 0);
+    assert_path_size(otrunc_path, 0);
+    assert_eq!(close(fd2), 0);
+    assert_eq!(close(fd1), 0);
+    assert_path_size(otrunc_path, 0);
+
+    let _ = linux_unlinkat(pending_path);
+    let _ = linux_unlinkat(multi_fd_path);
+    let _ = linux_unlinkat(append_path);
+    let _ = linux_unlinkat(zero_path);
+    let _ = linux_unlinkat(mmap_path);
+    let _ = linux_unlinkat(trunc_path);
+    let _ = linux_unlinkat(otrunc_path);
+
+    println!("pending_write_stat_smoke passed");
+    0
+}

--- a/user/src/bin/pipe_large_write_smoke.rs
+++ b/user/src/bin/pipe_large_write_smoke.rs
@@ -1,0 +1,125 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+#[macro_use]
+extern crate user;
+
+use alloc::vec;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use user::syscall::{
+    _yield, SIGPIPE, SignalAction, close, exit, fork, pipe, read, sigaction, sigreturn, syscall,
+    waitpid, write,
+};
+
+const TOTAL: usize = 96 * 1024 + 123;
+const READ_CHUNK: usize = 8191;
+const EPIPE: isize = -32;
+const SYSCALL_WRITE: usize = 64;
+const SYSCALL_FCNTL: usize = 25;
+const F_GETFL: usize = 3;
+const F_SETFL: usize = 4;
+const O_NONBLOCK: usize = 0x800;
+
+static SIGPIPE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+fn pattern(pos: usize) -> u8 {
+    pos.wrapping_mul(131).wrapping_add(17) as u8
+}
+
+fn sigpipe_handler() {
+    SIGPIPE_COUNT.fetch_add(1, Ordering::SeqCst);
+    sigreturn();
+}
+
+fn install_sigpipe_handler() {
+    let mut action = SignalAction::default();
+    action.handler = sigpipe_handler as usize;
+    assert_eq!(sigaction(SIGPIPE, Some(&action), None), 0);
+}
+
+fn fcntl(fd: usize, cmd: usize, arg: usize) -> isize {
+    syscall(SYSCALL_FCNTL, [fd, cmd, arg, 0, 0, 0])
+}
+
+fn wait_for_sigpipe_count(target: usize) {
+    for _ in 0..8 {
+        if SIGPIPE_COUNT.load(Ordering::SeqCst) >= target {
+            return;
+        }
+        _yield();
+    }
+}
+
+fn check_large_blocking_write() {
+    let mut fds = [0usize; 2];
+    assert_eq!(pipe(&mut fds), 0);
+
+    let pid = fork();
+    assert!(pid >= 0);
+    if pid == 0 {
+        close(fds[1]);
+        let mut buf = vec![0u8; READ_CHUNK];
+        let mut seen = 0usize;
+        while seen < TOTAL {
+            let want = core::cmp::min(READ_CHUNK, TOTAL - seen);
+            let n = read(fds[0], &mut buf[..want]);
+            assert!(n > 0);
+            let n = n as usize;
+            for i in 0..n {
+                assert_eq!(buf[i], pattern(seen + i));
+            }
+            seen += n;
+        }
+
+        let mut eof = [0u8; 1];
+        assert_eq!(read(fds[0], &mut eof), 0);
+        close(fds[0]);
+        exit(0);
+    }
+
+    close(fds[0]);
+    let mut data = vec![0u8; TOTAL];
+    for (i, byte) in data.iter_mut().enumerate() {
+        *byte = pattern(i);
+    }
+    assert_eq!(write(fds[1], data.as_slice()), TOTAL as isize);
+    close(fds[1]);
+
+    let mut exit_code = 0i32;
+    assert_eq!(waitpid(pid, &mut exit_code), pid);
+    assert_eq!(exit_code, 0);
+}
+
+fn check_nonblock_closed_reader_sigpipe() {
+    SIGPIPE_COUNT.store(0, Ordering::SeqCst);
+
+    let mut fds = [0usize; 2];
+    assert_eq!(pipe(&mut fds), 0);
+    let flags = fcntl(fds[1], F_GETFL, 0);
+    assert!(flags >= 0);
+    assert_eq!(fcntl(fds[1], F_SETFL, flags as usize | O_NONBLOCK), 0);
+    close(fds[0]);
+
+    assert_eq!(write(fds[1], &[0x5a]), EPIPE);
+    wait_for_sigpipe_count(1);
+    assert_eq!(SIGPIPE_COUNT.load(Ordering::SeqCst), 1);
+
+    assert_eq!(
+        syscall(SYSCALL_WRITE, [fds[1], usize::MAX - 4095, 1, 0, 0, 0]),
+        EPIPE
+    );
+    wait_for_sigpipe_count(2);
+    assert_eq!(SIGPIPE_COUNT.load(Ordering::SeqCst), 2);
+    close(fds[1]);
+}
+
+#[unsafe(no_mangle)]
+pub fn main() -> i32 {
+    install_sigpipe_handler();
+    check_large_blocking_write();
+    check_nonblock_closed_reader_sigpipe();
+
+    println!("pipe_large_write_smoke passed");
+    0
+}

--- a/user/src/bin/regular_file_select_smoke.rs
+++ b/user/src/bin/regular_file_select_smoke.rs
@@ -1,0 +1,115 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+#[macro_use]
+extern crate user;
+
+use alloc::string::String;
+use user::syscall::{CREATE, RDONLY, RDWR, TRUNC, TimeSpec, close, open, syscall, write};
+
+const SYSCALL_OPENAT: usize = 56;
+const SYSCALL_PSELECT6: usize = 72;
+const SYSCALL_PPOLL: usize = 73;
+
+const AT_FDCWD: isize = -100;
+const O_PATH: usize = 0x200000;
+
+const POLLIN: i16 = 0x0001;
+const POLLOUT: i16 = 0x0004;
+const POLLNVAL: i16 = 0x0020;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct PollFd {
+    fd: i32,
+    events: i16,
+    revents: i16,
+}
+
+fn set_fd(fdset: &mut [u8], fd: usize) {
+    fdset[fd / 8] |= 1u8 << (fd % 8);
+}
+
+fn is_fd_set(fdset: &[u8], fd: usize) -> bool {
+    (fdset[fd / 8] & (1u8 << (fd % 8))) != 0
+}
+
+fn with_c_path<T>(path: &str, f: impl FnOnce(*const u8) -> T) -> T {
+    let mut owned = String::from(path);
+    owned.push('\0');
+    f(owned.as_ptr())
+}
+
+fn linux_openat(dirfd: isize, path: &str, flags: usize, mode: usize) -> isize {
+    with_c_path(path, |ptr| {
+        syscall(
+            SYSCALL_OPENAT,
+            [dirfd as usize, ptr as usize, flags, mode, 0, 0],
+        )
+    })
+}
+
+#[unsafe(no_mangle)]
+pub fn main() -> i32 {
+    let path = "/tmp/regular_file_select_smoke";
+    let fd = open(path, RDWR | CREATE | TRUNC);
+    assert!(fd >= 0);
+    let fd = fd as usize;
+    assert_eq!(write(fd, b"x"), 1);
+    close(fd);
+
+    let fd = open(path, RDONLY);
+    assert!(fd >= 0);
+    let fd = fd as usize;
+
+    let nfds = fd + 1;
+    let mut writefds = [0u8; 32];
+    assert!(nfds <= writefds.len() * 8);
+    set_fd(&mut writefds, fd);
+    let timeout = TimeSpec { sec: 0, nsec: 0 };
+
+    let ready = syscall(
+        SYSCALL_PSELECT6,
+        [
+            nfds,
+            0,
+            writefds.as_mut_ptr() as usize,
+            0,
+            &timeout as *const TimeSpec as usize,
+            0,
+        ],
+    );
+    assert_eq!(ready, 1);
+    assert!(is_fd_set(&writefds, fd));
+
+    close(fd);
+
+    let fd = linux_openat(AT_FDCWD, path, O_PATH, 0);
+    assert!(fd >= 0);
+    let fd = fd as usize;
+    let mut pfd = PollFd {
+        fd: fd as i32,
+        events: POLLIN | POLLOUT,
+        revents: 0,
+    };
+    let timeout = TimeSpec { sec: 0, nsec: 0 };
+    let ready = syscall(
+        SYSCALL_PPOLL,
+        [
+            &mut pfd as *mut PollFd as usize,
+            1,
+            &timeout as *const TimeSpec as usize,
+            0,
+            0,
+            0,
+        ],
+    );
+    assert_eq!(ready, 1);
+    assert_eq!(pfd.revents, POLLNVAL);
+
+    close(fd);
+    println!("regular_file_select_smoke passed");
+    0
+}

--- a/user/src/bin/submit_script.rs
+++ b/user/src/bin/submit_script.rs
@@ -28,6 +28,8 @@ const LTP_ENV_ROOT_GLIBC: &[u8] = b"LTPROOT=/glibc/ltp\0";
 // Optional adapter for the bundled musl sched_* libc wrappers:
 // const LTP_ENV_MUSL_SCHED_PRELOAD: &[u8] = b"LD_PRELOAD=/extra/libltp_sched_fix.so\0";
 const LTP_ENV_TIMEOUT_MUL_SLOW: &[u8] = b"LTP_TIMEOUT_MUL=4\0";
+const FOCUS_VFS_SMOKES: bool = false;
+const VFS_SMOKES: [&str; 1] = ["/user/path_cache_invalidation_smoke.bin"];
 const FOCUS_READINESS_SMOKES: bool = false;
 const READINESS_SMOKES: [&str; 15] = [
     "/user/nested_epoll_smoke.bin",
@@ -301,6 +303,9 @@ fn try_poweroff() -> ! {
 pub fn main() -> i32 {
     // only run for riscv arch
     if cfg!(target_arch = "riscv64") {
+        if FOCUS_VFS_SMOKES {
+            run_named_cases("vfs-smoke", VFS_SMOKES.as_ref());
+        }
         if FOCUS_READINESS_SMOKES {
             run_named_cases("readiness-smoke", READINESS_SMOKES.as_ref());
         }

--- a/user/src/bin/submit_script.rs
+++ b/user/src/bin/submit_script.rs
@@ -29,7 +29,7 @@ const LTP_ENV_ROOT_GLIBC: &[u8] = b"LTPROOT=/glibc/ltp\0";
 // const LTP_ENV_MUSL_SCHED_PRELOAD: &[u8] = b"LD_PRELOAD=/extra/libltp_sched_fix.so\0";
 const LTP_ENV_TIMEOUT_MUL_SLOW: &[u8] = b"LTP_TIMEOUT_MUL=4\0";
 const FOCUS_READINESS_SMOKES: bool = false;
-const READINESS_SMOKES: [&str; 14] = [
+const READINESS_SMOKES: [&str; 15] = [
     "/user/nested_epoll_smoke.bin",
     "/user/nested_epoll_ctl_wakeup_smoke.bin",
     "/user/nested_epoll_ctl_del_smoke.bin",
@@ -43,6 +43,7 @@ const READINESS_SMOKES: [&str; 14] = [
     "/user/mq_notify_signal_smoke.bin",
     "/user/mq_unlink_epoll_smoke.bin",
     "/user/timerfd_epoll_smoke.bin",
+    "/user/regular_file_select_smoke.bin",
     "/user/dup3_lock_cleanup_smoke.bin",
 ];
 const FOCUS_PROCFS_SMOKES: bool = false;

--- a/user/src/bin/submit_script.rs
+++ b/user/src/bin/submit_script.rs
@@ -29,7 +29,10 @@ const LTP_ENV_ROOT_GLIBC: &[u8] = b"LTPROOT=/glibc/ltp\0";
 // const LTP_ENV_MUSL_SCHED_PRELOAD: &[u8] = b"LD_PRELOAD=/extra/libltp_sched_fix.so\0";
 const LTP_ENV_TIMEOUT_MUL_SLOW: &[u8] = b"LTP_TIMEOUT_MUL=4\0";
 const FOCUS_VFS_SMOKES: bool = false;
-const VFS_SMOKES: [&str; 1] = ["/user/path_cache_invalidation_smoke.bin"];
+const VFS_SMOKES: [&str; 2] = [
+    "/user/path_cache_invalidation_smoke.bin",
+    "/user/exec_write_count_smoke.bin",
+];
 const FOCUS_READINESS_SMOKES: bool = false;
 const READINESS_SMOKES: [&str; 15] = [
     "/user/nested_epoll_smoke.bin",

--- a/user/src/bin/submit_script.rs
+++ b/user/src/bin/submit_script.rs
@@ -29,8 +29,9 @@ const LTP_ENV_ROOT_GLIBC: &[u8] = b"LTPROOT=/glibc/ltp\0";
 // const LTP_ENV_MUSL_SCHED_PRELOAD: &[u8] = b"LD_PRELOAD=/extra/libltp_sched_fix.so\0";
 const LTP_ENV_TIMEOUT_MUL_SLOW: &[u8] = b"LTP_TIMEOUT_MUL=4\0";
 const FOCUS_VFS_SMOKES: bool = false;
-const VFS_SMOKES: [&str; 2] = [
+const VFS_SMOKES: [&str; 3] = [
     "/user/path_cache_invalidation_smoke.bin",
+    "/user/pending_write_stat_smoke.bin",
     "/user/exec_write_count_smoke.bin",
 ];
 const FOCUS_READINESS_SMOKES: bool = false;


### PR DESCRIPTION
## 概要

- 为显式 handoff 唤醒保留 Linux 风格的同步唤醒放置语义。
- 在 `os` 子仓库中增加 pending sync-wakeup 来源 hart，避免 `on_cpu` 竞态下丢失原始唤醒方亲和性。
- 让 pipe 直接读写等待者走同步唤醒路径，同时保持 poll/epoll 通知等待者使用普通唤醒路径。

## 验证

- `cargo fmt`
- `TMPDIR=$PWD/../.tmp ARCH=riscv64 cargo check --manifest-path Cargo.toml --target riscv64gc-unknown-none-elf`
- `TMPDIR=$PWD/../.tmp ARCH=loongarch64 cargo check --manifest-path Cargo.toml --target loongarch64-unknown-none`
- `python3 tools/os_cmd_bench.py --arch riscv64 --cmd 'pipe_large_write_smoke.bin' --repeat 1`\n- `python3 tools/os_cmd_bench.py --arch riscv64 --cmd 'epoll_ctl_wakeup_smoke.bin' --repeat 1`\n\n## 说明\n\n本 PR 更新 workspace 中的 `os` 子仓库指针。同步唤醒修改属于调度语义改进；聚焦 `lat_ctx` 测量波动较大，尚不能证明稳定 benchmark 收益，因此这里不把它描述为明确的 lmbench 提升。\n\n关联 `os` 子仓库 PR：HITOSTeam/OS#20